### PR TITLE
chore: Update README due to f5-downloads migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # F5 BIG-IP Application Services 3 Extension (AS3)
 
 [![Releases](https://img.shields.io/github/release/f5networks/f5-appsvcs-extension.svg)](https://github.com/f5networks/f5-appsvcs-extension/releases)
-[![Issues](https://img.shields.io/github/issues/f5networks/f5-appsvcs-extension.svg)](https://github.com/f5networks/f5-appsvcs-extension/issues)
 
 ## Introduction
 F5 BIG-IP Application Services 3 Extension (F5 BIG-IP AS3) is a flexible, low-overhead mechanism for managing application-specific configurations on a F5 BIG-IP system. BIG-IP AS3 uses a declarative model, meaning you provide a JSON declaration rather than a set of imperative commands.
 
-**IMPORTANT** Beginning with BIG-IP AS3 3.15.0, the RPM, Postman Collection, and checksum files will no longer be located in the **/dist** directory in this repository.  These files can be found on the [Release page](https://github.com/F5Networks/f5-appsvcs-extension/releases), as **Assets**.  
+**IMPORTANT** Beginning with BIG-IP AS3 3.15.0, the RPM, Postman Collection, and checksum files will no longer be located in the **/dist** directory in this repository. Historical files remain available on the archived [Release page](https://github.com/F5Networks/f5-appsvcs-extension/releases), under **Assets**.
 You can find historical files by using the **Branch** drop-down, clicking the **Tags** tab, and then selecting the appropriate release.
+
+RPMs are also available for manual download from [MyF5 Downloads](https://my.f5.com/manage/s/downloads).
 
 ## Documentation
 For the documentation on BIG-IP AS3, including download, installation, and usage instructions, see the BIG-IP AS3 [User](https://clouddocs.f5.com/products/extensions/f5-appsvcs-extension/latest/userguide/) and [Reference](https://clouddocs.f5.com/products/extensions/f5-appsvcs-extension/latest/refguide/) guides at http://clouddocs.f5.com/products/extensions/f5-appsvcs-extension/latest/.
@@ -16,18 +17,16 @@ For the documentation on BIG-IP AS3, including download, installation, and usage
 The BIG-IP AS3 documentation contains a wide variety of example declarations you can use directly or modify to suit your needs.  See the [Examples](https://clouddocs.f5.com/products/extensions/f5-appsvcs-extension/latest/userguide/examples.html) and [Additional Examples](https://clouddocs.f5.com/products/extensions/f5-appsvcs-extension/latest/declarations/) pages.
 
 ## Filing Issues and Getting Help
-If you come across a bug or other issue when using BIG-IP AS3, use [GitHub Issues](https://github.com/F5Networks/f5-appsvcs-extension/issues) to submit an issue for our team.  You can also see the current known issues on that page, which are tagged with a purple Known Issue label.  
+If you encounter a bug or other issue while using BIG-IP AS3, use [F5 Technical Support](https://www.f5.com/support) to submit it to our team.
 
-**Important**: Github Issues are consistently monitored by F5 staff, but should be considered as best effort only and you should not expect to receive the same level of response as provided by F5 Support. Please open a case as described below with F5 if this is a critical issue.
-
-Because BIG-IP AS3 has been created and fully tested by F5 Networks, it is fully supported by F5. This means you can get assistance if necessary from [F5 Technical Support](https://support.f5.com/csp/article/K25327565).  
+**Important**: As of February 2026, GitHub issues are no longer being monitored by F5 support staff.
 
 Be sure to see the [Support page](SUPPORT.md) in this repo for more details and supported versions of BIG-IP AS3.  
 
 
 ## Copyright
 
-Copyright 2014-2025 F5, Inc.
+Copyright 2014-2026 F5, Inc.
 
 
 ### F5 Networks Contributor License Agreement


### PR DESCRIPTION
We are moving away from Github releases and to the internal f5-downloads. This README describes how our customers can update to these changes.